### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "memorystore": "^1.6.7",
     "mongoose": "^8.18.2",
     "morgan": "^1.10.1",
-    "lusca": "^1.7.0"
+    "lusca": "^1.7.0",
+    "express-rate-limit": "^8.2.1"
   },
   "jest": {
     "testPathIgnorePatterns": [


### PR DESCRIPTION
Potential fix for [https://github.com/SREEMT/hackUMBC-26-Project/security/code-scanning/1](https://github.com/SREEMT/hackUMBC-26-Project/security/code-scanning/1)

To fix the problem, we should add rate limiting middleware to the `/loginuser` route to restrict how many login attempts any particular client or IP can make in a short period. The industry-standard way to do this in Express is with `express-rate-limit`. We need to add a dependency on `express-rate-limit`, create a rate limiter (for example, limiting to 5 requests per 5 minutes per IP), and apply it specifically to the `/loginuser` endpoint to avoid affecting other routes unnecessarily.

**Steps to implement:**
1. Import `express-rate-limit` at the top of the file.
2. Create and configure a login rate limiter, e.g., 5 requests per 5 minutes per IP.
3. Insert the configured rate limiter as middleware just for the `/loginuser` route.
4. There is no need to change anything else about the existing login functionality, so the rest of the route logic remains untouched.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
